### PR TITLE
feat: Handle SIGTERM and SIGINT gracefully

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,6 +1,7 @@
 /**
- * @description controller is to handle different types of function invocation
+ * @description Controller that and handles different types of function invocation and lifecycle events.
  */
 export interface Controller {
   init(): void;
+  shutdown(): void;
 }

--- a/src/controller/http-controller.ts
+++ b/src/controller/http-controller.ts
@@ -1,3 +1,4 @@
+import { Server } from "node:http";
 import bodyParser from "body-parser";
 import cors from "cors";
 import express from "express";
@@ -18,6 +19,7 @@ export class HttpController implements Controller {
   private readonly _invoker: Invoker;
   private readonly _ignoredPaths: string[] = ["/favicon.ico"];
   private readonly _port = config.port;
+  private _server: Server | undefined;
 
   constructor() {
     this._app = express();
@@ -25,7 +27,7 @@ export class HttpController implements Controller {
   }
 
   init() {
-    this._app
+    this._server = this._app
       .use(morgan("tiny"))
       .use(
         cors({
@@ -67,5 +69,16 @@ export class HttpController implements Controller {
       .listen(this._port, () => {
         logger.info(`HttpController is listening on port ${this._port}`);
       });
+  }
+
+  shutdown(): void {
+    logger.info("HttpController shutting down...");
+    if (!this._server) {
+      return;
+    }
+
+    this._server.close(() => {
+      logger.info("HttpController shutdown complete");
+    });
   }
 }

--- a/src/controller/ws-controller.ts
+++ b/src/controller/ws-controller.ts
@@ -103,6 +103,13 @@ export class WSController implements Controller {
       logger.info(`WSController is listening on port ${this._port}`);
     });
   }
+
+  shutdown(): void {
+    logger.info("WSController shutting down...");
+    this._server.close(() => {
+      logger.info("WSController shutdown complete");
+    });
+  }
 }
 
 type Message = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,21 @@ const lambdaController = new LambdaController();
 httpController.init();
 wsController.init();
 lambdaController.init();
+
+//#region Graceful Shutdown
+const shutdownControllers = () => {
+  httpController.shutdown();
+  wsController.shutdown();
+  lambdaController.shutdown();
+};
+
+process.on("SIGTERM", async () => {
+  shutdownControllers();
+  process.exit(0);
+});
+
+process.on("SIGINT", async () => {
+  shutdownControllers();
+  process.exit(0);
+});
+//#endregion

--- a/test/controller/http-controller.spec.ts
+++ b/test/controller/http-controller.spec.ts
@@ -1,0 +1,82 @@
+import { Invoker } from "src/invoker";
+
+//#region Mock express module
+const mockApp = {
+  use: vi.fn().mockReturnThis(),
+  all: vi.fn().mockReturnThis(),
+  listen: vi.fn((_, callback) => {
+    callback?.();
+    return { close: vi.fn() };
+  }),
+};
+
+vi.mock("express", () => ({
+  default: vi.fn(() => mockApp),
+}));
+//#endregion
+
+vi.mock("../../src/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/invoker", () => ({
+  Invoker: vi.fn(function (this: Invoker) {
+    this.httpInvoke = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      body: "test response",
+    });
+  }),
+}));
+
+vi.mock("../../src/config", () => ({
+  config: {
+    port: 3000,
+    getFunctionByPath: vi.fn().mockReturnValue("test-function"),
+    getCorsAllowOrigin: vi.fn().mockReturnValue([]),
+    isFunctionOnV1HttpRequestPayload: vi.fn().mockReturnValue(false),
+  },
+}));
+
+describe("HttpController", () => {
+  beforeEach(vi.clearAllMocks);
+
+  afterEach(vi.resetModules);
+
+  describe("init()", () => {
+    it("should start server on configured port", async () => {
+      const { HttpController } = await import(
+        "../../src/controller/http-controller"
+      );
+      const { config } = await import("../../src/config");
+      const { logger } = await import("../../src/logger");
+
+      const controller = new HttpController();
+      controller.init();
+
+      expect(mockApp.listen).toHaveBeenCalledWith(
+        config.port,
+        expect.any(Function),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        `HttpController is listening on port ${config.port}`,
+      );
+    });
+
+    it("should configure middleware", async () => {
+      const { HttpController } = await import(
+        "../../src/controller/http-controller"
+      );
+
+      const controller = new HttpController();
+      controller.init();
+
+      expect(mockApp.use).toHaveBeenCalled();
+      expect(mockApp.all).toHaveBeenCalledWith("*", expect.any(Function));
+    });
+  });
+});

--- a/test/controller/lambda-controller.spec.ts
+++ b/test/controller/lambda-controller.spec.ts
@@ -1,0 +1,101 @@
+import { Invoker } from "src/invoker";
+
+//#region Mock express module
+const mockApp = {
+  use: vi.fn().mockReturnThis(),
+  post: vi.fn().mockReturnThis(),
+  listen: vi.fn((_, callback) => {
+    callback?.();
+    return { close: vi.fn() };
+  }),
+};
+
+vi.mock("express", () => ({
+  default: vi.fn(() => mockApp),
+}));
+//#endregion
+
+vi.mock("../../src/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/invoker", () => ({
+  Invoker: vi.fn(function (this: Invoker) {
+    this.httpInvoke = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      body: "test response",
+    });
+    this.getUrl = vi
+      .fn()
+      .mockReturnValue(new URL("http://test-function:8080/invoke"));
+  }),
+}));
+
+vi.mock("../../src/config", () => ({
+  config: {
+    port: 3000,
+  },
+}));
+
+vi.mock("../../src/throttle", () => ({
+  throttle: {
+    add: vi.fn((_name, task) => task()),
+  },
+}));
+
+vi.mock("http-proxy", () => ({
+  createProxyServer: vi.fn().mockReturnValue({
+    web: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+
+describe("LambdaController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  describe("init()", () => {
+    it("should start server on configured port + 2", async () => {
+      const { LambdaController } = await import(
+        "../../src/controller/lambda-controller"
+      );
+      const { logger } = await import("../../src/logger");
+      const { config } = await import("../../src/config");
+
+      const controller = new LambdaController();
+      controller.init();
+
+      expect(mockApp.listen).toHaveBeenCalledWith(
+        config.port + 2,
+        expect.any(Function),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        `LambdaController is listening on port ${config.port + 2}`,
+      );
+    });
+
+    it("should configure Lambda invocation endpoint", async () => {
+      const { LambdaController } = await import(
+        "../../src/controller/lambda-controller"
+      );
+
+      const controller = new LambdaController();
+      controller.init();
+
+      expect(mockApp.post).toHaveBeenCalledWith(
+        "/2015-03-31/functions/:functionName/invocations",
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/test/controller/ws-controller.spec.ts
+++ b/test/controller/ws-controller.spec.ts
@@ -1,0 +1,93 @@
+import type { Server } from "node:http";
+import { Invoker } from "src/invoker";
+
+//#region express module
+const mockServer = {
+  listen: vi.fn((_, callback) => {
+    callback?.();
+    return {} as Server;
+  }),
+  on: vi.fn(),
+};
+
+const mockApp = {
+  use: vi.fn().mockReturnThis(),
+  post: vi.fn().mockReturnThis(),
+};
+
+vi.mock("express", () => ({
+  default: Object.assign(
+    vi.fn(() => mockApp),
+    {
+      raw: vi.fn(() => vi.fn()),
+    },
+  ),
+}));
+//#endregion
+
+vi.mock("node:http", () => ({
+  createServer: vi.fn(() => mockServer),
+}));
+
+vi.mock("../../src/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/invoker", () => ({
+  Invoker: vi.fn(function (this: Invoker) {
+    this.wsInvoke = vi.fn().mockResolvedValue({});
+  }),
+}));
+
+vi.mock("../../src/config", () => ({
+  config: {
+    port: 3000,
+    wsFunction: "test-ws-function",
+  },
+}));
+
+describe("WSController", () => {
+  beforeEach(vi.clearAllMocks);
+
+  afterEach(vi.resetModules);
+
+  describe("init()", () => {
+    it("should start server on configured port + 1", async () => {
+      const { WSController } = await import(
+        "../../src/controller/ws-controller"
+      );
+      const { config } = await import("../../src/config");
+      const { logger } = await import("../../src/logger");
+
+      const controller = new WSController();
+      controller.init();
+
+      expect(mockServer.listen).toHaveBeenCalledWith(
+        config.port + 1,
+        expect.any(Function),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        `WSController is listening on port ${config.port + 1}`,
+      );
+    });
+
+    it("should configure connection management endpoint", async () => {
+      const { WSController } = await import(
+        "../../src/controller/ws-controller"
+      );
+
+      const controller = new WSController();
+      controller.init();
+
+      expect(mockApp.post).toHaveBeenCalledWith(
+        "/:stage/@connections/:connectionId",
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/test/controller/ws-controller.spec.ts
+++ b/test/controller/ws-controller.spec.ts
@@ -8,6 +8,7 @@ const mockServer = {
     return {} as Server;
   }),
   on: vi.fn(),
+  close: vi.fn((callback) => callback?.()),
 };
 
 const mockApp = {
@@ -88,6 +89,22 @@ describe("WSController", () => {
         "/:stage/@connections/:connectionId",
         expect.any(Function),
       );
+    });
+  });
+
+  describe("shutdown()", () => {
+    it("should close server and log shutdown messages", async () => {
+      const { WSController } = await import(
+        "../../src/controller/ws-controller"
+      );
+      const { logger } = await import("../../src/logger");
+
+      const controller = new WSController();
+      controller.init(); // Initialize to create server
+      controller.shutdown();
+
+      expect(logger.info).toHaveBeenCalledWith("WSController shutting down...");
+      expect(mockServer.close).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #5. This handles SIGTERM and SIGINT gracefully on lite-hub.

Test done, with example/docker-compose.yaml:
<img width="870" height="911" alt="image" src="https://github.com/user-attachments/assets/daa59df5-4079-4068-b1e9-230dd7512722" />
